### PR TITLE
Support All OSes main font out of the box

### DIFF
--- a/preset.css
+++ b/preset.css
@@ -26,7 +26,7 @@ A simple CSS preset to enable box-sizing, set some text rendering options to dec
 }
 
 html {
-  font-family: sans-serif;
+  font-family: -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif;
   -webkit-text-size-adjust: 100%;
 }
 


### PR DESCRIPTION
I took (stole?) this concept right outta Facebook. In all their OSS projects, and in facebook.com itself, they follow this rule where they add support for **all** OSes, and come to think about it, that is the better approach if one is looking for a much better integration of the web page's look with the system that the user is on.

To see it in action: https://github.com/facebook/Docusaurus/blob/b374391446d1df7fca26cb9c390d72b9dc4b433b/lib/static/css/main.css#L51

lmk wdyt :)

r?

Thanks!